### PR TITLE
Fix: Github info

### DIFF
--- a/index.html
+++ b/index.html
@@ -1152,7 +1152,7 @@
             async function fetchUserInfoFromGitHub(uid) {
                 let json, res;
                 try {
-                    res = await fetch(`https://api.github.com/users/${uid}`);
+                    res = await fetch(`https://api.github.com/user/${uid}`);
                     json = await res.json();
                 } catch (err) {
                     throw new Error(err);


### PR DESCRIPTION
When not present on the auth process, user's Github info is gathered from the Github API. However, the API endpoint to get info using the user id is `/user/:id`, while `users` is for `/users/:username`.